### PR TITLE
Update rocket routes to be async

### DIFF
--- a/src/api/customers.rs
+++ b/src/api/customers.rs
@@ -2,9 +2,9 @@
 
 use rocket::{
     response::status::Created,
+    serde::json::Json,
     State,
 };
-use rocket::serde::json::Json;
 
 use crate::{
     api::error::{
@@ -19,7 +19,7 @@ use crate::{
 
 /** `GET /customers/<id>` */
 #[get("/<id>")]
-pub fn get(id: CustomerId, app: &State<Resolver>) -> Result<Json<CustomerWithOrders>, Error> {
+pub async fn get(id: CustomerId, app: &State<Resolver>) -> Result<Json<CustomerWithOrders>, Error> {
     let query = app.get_customer_with_orders_query();
 
     match query.get_customer_with_orders(GetCustomerWithOrders { id })? {
@@ -30,7 +30,7 @@ pub fn get(id: CustomerId, app: &State<Resolver>) -> Result<Json<CustomerWithOrd
 
 /** `PUT /customers` */
 #[put("/", format = "application/json")]
-pub fn create(app: &State<Resolver>) -> Result<Created<Json<CustomerId>>, Error> {
+pub async fn create(app: &State<Resolver>) -> Result<Created<Json<CustomerId>>, Error> {
     app.transaction(|app| {
         let id = app.customer_id();
 

--- a/src/api/id.rs
+++ b/src/api/id.rs
@@ -1,6 +1,4 @@
-use rocket::{
-    request::FromParam,
-};
+use rocket::request::FromParam;
 use std::convert::TryFrom;
 
 use crate::domain::{

--- a/src/api/orders.rs
+++ b/src/api/orders.rs
@@ -2,9 +2,9 @@
 
 use rocket::{
     response::status::Created,
+    serde::json::Json,
     State,
 };
-use rocket::serde::json::Json;
 
 use crate::{
     api::error::{
@@ -21,7 +21,7 @@ use crate::{
 
 /** `GET /orders/<id>` */
 #[get("/<id>")]
-pub fn get(id: OrderId, app: &State<Resolver>) -> Result<Json<OrderWithProducts>, Error> {
+pub async fn get(id: OrderId, app: &State<Resolver>) -> Result<Json<OrderWithProducts>, Error> {
     let query = app.get_order_with_products_query();
 
     match query.get_order_with_products(GetOrderWithProducts { id })? {
@@ -37,7 +37,10 @@ pub struct Create {
 
 /** `PUT /orders` */
 #[put("/", format = "application/json", data = "<data>")]
-pub fn create(data: Json<Create>, app: &State<Resolver>) -> Result<Created<Json<OrderId>>, Error> {
+pub async fn create(
+    data: Json<Create>,
+    app: &State<Resolver>,
+) -> Result<Created<Json<OrderId>>, Error> {
     app.transaction(|app| {
         let id = app.order_id();
         let mut command = app.create_order_command();
@@ -66,7 +69,7 @@ pub struct ProductQuantity {
     format = "application/json",
     data = "<data>"
 )]
-pub fn add_or_update_product(
+pub async fn add_or_update_product(
     id: OrderId,
     product_id: ProductId,
     data: Json<ProductQuantity>,

--- a/src/api/products.rs
+++ b/src/api/products.rs
@@ -2,9 +2,9 @@
 
 use rocket::{
     response::status::Created,
+    serde::json::Json,
     State,
 };
-use rocket::serde::json::Json;
 
 use crate::{
     api::error::{
@@ -26,7 +26,7 @@ pub struct Get {
 
 /** `GET /products/<id>` */
 #[get("/<id>")]
-pub fn get(id: ProductId, app: &State<Resolver>) -> Result<Json<Get>, Error> {
+pub async fn get(id: ProductId, app: &State<Resolver>) -> Result<Json<Get>, Error> {
     let query = app.get_product_query();
 
     match query.get_product(GetProduct { id })? {
@@ -51,7 +51,10 @@ pub struct Create {
 
 /** `PUT /products` */
 #[put("/", format = "application/json", data = "<data>")]
-pub fn create(data: Json<Create>, app: &State<Resolver>) -> Result<Created<Json<ProductId>>, Error> {
+pub async fn create(
+    data: Json<Create>,
+    app: &State<Resolver>,
+) -> Result<Created<Json<ProductId>>, Error> {
     app.transaction(|app| {
         let id = app.product_id();
         let mut command = app.create_product_command();
@@ -72,7 +75,7 @@ pub fn create(data: Json<Create>, app: &State<Resolver>) -> Result<Created<Json<
 
 /** `POST /products/<id>/title/<title>` */
 #[post("/<id>/title/<title>")]
-pub fn set_title(id: ProductId, title: String, app: &State<Resolver>) -> Result<(), Error> {
+pub async fn set_title(id: ProductId, title: String, app: &State<Resolver>) -> Result<(), Error> {
     app.transaction(|app| {
         let mut command = app.set_product_title_command();
 

--- a/tests/orders.rs
+++ b/tests/orders.rs
@@ -1,54 +1,68 @@
 #[macro_use]
+extern crate rocket;
+
+#[macro_use]
 extern crate serde_json;
 
 use rocket::{
     http::Status,
-    local::blocking::Client,
+    local::asynchronous::Client,
 };
 
-#[test]
-fn set_get() {
-    let app = Client::untracked(shop::api::init()).expect("invalid app");
+#[async_test]
+async fn set_get() {
+    let app = Client::untracked(shop::api::init())
+        .await
+        .expect("invalid app");
 
-    let product_id: String = app
-        .put("/products")
-        .json(&json!({
-            "title": "A new product",
-            "price": {
-                "usd": {
-                    "cents": 123
+    let product_id: String = {
+        let get = app
+            .put("/products")
+            .json(&json!({
+                "title": "A new product",
+                "price": {
+                    "usd": {
+                        "cents": 123
+                    }
                 }
-            }
-        }))
-        .dispatch()
-        .into_json()
-        .expect("invalid id");
+            }))
+            .dispatch()
+            .await;
 
-    let customer_id: String = app
-        .put("/customers")
-        .json(&json!({}))
-        .dispatch()
-        .into_json()
-        .expect("invalid id");
+        serde_json::from_str(&get.into_string().await.expect("missing body"))
+            .expect("invalid value")
+    };
+
+    let customer_id: String = {
+        let get = app.put("/customers").json(&json!({})).dispatch().await;
+
+        serde_json::from_str(&get.into_string().await.expect("missing body"))
+            .expect("invalid value")
+    };
 
     let put = app
         .put("/orders")
         .json(&json!({ "customer": customer_id }))
-        .dispatch();
+        .dispatch()
+        .await;
 
     assert_eq!(Status::Created, put.status());
-    let order_id: String = put.into_json().expect("invalid id");
+    let order_id: String = serde_json::from_str(&put.into_string().await.expect("missing body"))
+        .expect("invalid value");
 
     app.post(format!("/orders/{}/products/{}", order_id, product_id))
         .json(&json!({
             "quantity": 4
         }))
-        .dispatch();
+        .dispatch()
+        .await;
 
-    let get = app.get(format!("/orders/{}", order_id)).dispatch();
+    let get = app.get(format!("/orders/{}", order_id)).dispatch().await;
 
     assert_eq!(Status::Ok, get.status());
-    let order: serde_json::Value = get.into_json().expect("invalid order");
+    let order: serde_json::Value =
+        serde_json::from_str(&get.into_string().await.expect("missing body"))
+            .expect("invalid value");
 
     assert_eq!(
         1,

--- a/tests/products.rs
+++ b/tests/products.rs
@@ -1,14 +1,19 @@
 #[macro_use]
+extern crate rocket;
+
+#[macro_use]
 extern crate serde_json;
 
 use rocket::{
     http::Status,
-    local::blocking::Client,
+    local::asynchronous::Client,
 };
 
-#[test]
-fn set_get() {
-    let app = Client::untracked(shop::api::init()).expect("invalid app");
+#[async_test]
+async fn set_get() {
+    let app = Client::untracked(shop::api::init())
+        .await
+        .expect("invalid app");
 
     let put = app
         .put("/products")
@@ -20,15 +25,19 @@ fn set_get() {
                 }
             }
         }))
-        .dispatch();
+        .dispatch()
+        .await;
 
     assert_eq!(Status::Created, put.status());
-    let id: String = put.into_json().expect("invalid id");
+    let id: String = serde_json::from_str(&put.into_string().await.expect("missing body"))
+        .expect("invalid value");
 
-    let get = app.get(format!("/products/{}", id)).dispatch();
+    let get = app.get(format!("/products/{}", id)).dispatch().await;
 
     assert_eq!(Status::Ok, get.status());
-    let product: serde_json::Value = get.into_json().expect("invalid product");
+    let product: serde_json::Value =
+        serde_json::from_str(&get.into_string().await.expect("missing body"))
+            .expect("invalid value");
 
     assert_eq!(
         "A new product",


### PR DESCRIPTION
This is part 2 of moving this app to `async`/`await` by updating the API and integration tests to use `async`/`await`.