### PR TITLE
Refactor async domain to use async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 name = "shop"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "auto_impl",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ version = "~0.4"
 [dependencies.once_cell]
 version = "~1"
 
+[dependencies.async-trait]
+version = "~0.1"
+
 [dev-dependencies.tokio]
 version = "~1"
 features = ["macros"]

--- a/src/api/customers.rs
+++ b/src/api/customers.rs
@@ -36,11 +36,11 @@ pub async fn create(app: &State<App>) -> Result<Created<Json<CustomerId>>, Error
     app.transaction2(|app| async move {
         let id = app.customer_id();
 
-        let command = app.create_customer_command();
+        let mut command = app.create_customer_command();
 
         let id = id.get()?;
 
-        command.create_customer(CreateCustomer { id }).await?;
+        command.execute(CreateCustomer { id }).await?;
 
         let location = format!("/customers/{}", id);
 

--- a/src/api/customers.rs
+++ b/src/api/customers.rs
@@ -20,14 +20,15 @@ use crate::{
 /** `GET /customers/<id>` */
 #[get("/<id>")]
 pub async fn get(id: CustomerId, app: &State<App>) -> Result<Json<CustomerWithOrders>, Error> {
-    app.transaction(|app| {
+    app.transaction2(|app| async move {
         let query = app.get_customer_with_orders_query();
 
-        match query.get_customer_with_orders(GetCustomerWithOrders { id })? {
+        match query.execute(GetCustomerWithOrders { id }).await? {
             Some(customer) => Ok(Json(customer)),
             None => Err(Error::NotFound(error::msg("customer not found"))),
         }
     })
+    .await
 }
 
 /** `PUT /customers` */

--- a/src/domain/customers/commands/create_customer.rs
+++ b/src/domain/customers/commands/create_customer.rs
@@ -6,12 +6,16 @@ use crate::domain::{
     Error,
 };
 
-pub type Result = ::std::result::Result<(), Error>;
+type Result = ::std::result::Result<(), Error>;
 
 /** Input for a `CreateCustomerCommand`. */
 #[derive(Clone, Deserialize)]
 pub struct CreateCustomer {
     pub id: CustomerId,
+}
+
+impl CommandArgs for CreateCustomer {
+    type Output = Result;
 }
 
 impl CreateCustomer {
@@ -40,7 +44,7 @@ impl CreateCustomer {
 
 impl Resolver {
     /** Create a customer. */
-    pub fn create_customer_command(&self) -> impl Command<CreateCustomer, Result> {
+    pub fn create_customer_command(&self) -> impl Command<CreateCustomer> {
         self.command(|resolver, mut command: CreateCustomer| async move {
             let store = resolver.customer_store();
             let active_transaction = resolver.active_transaction();

--- a/src/domain/customers/commands/mod.rs
+++ b/src/domain/customers/commands/mod.rs
@@ -1,4 +1,5 @@
 /*! Commands for modifying customer state. */
 
-pub mod create_customer;
-pub use self::create_customer::CreateCustomer;
+mod create_customer;
+
+pub use self::create_customer::*;

--- a/src/domain/customers/commands/mod.rs
+++ b/src/domain/customers/commands/mod.rs
@@ -1,7 +1,4 @@
 /*! Commands for modifying customer state. */
 
 pub mod create_customer;
-pub use self::create_customer::{
-    CreateCustomer,
-    CreateCustomerCommand,
-};
+pub use self::create_customer::CreateCustomer;

--- a/src/domain/customers/queries/mod.rs
+++ b/src/domain/customers/queries/mod.rs
@@ -1,14 +1,9 @@
 /*! Queries for fetching customer state. */
 
-pub mod get_customer;
-pub use self::get_customer::{
-    GetCustomer,
-    GetCustomerQuery,
-};
+mod get_customer;
+mod get_customer_with_orders;
 
-pub mod get_customer_with_orders;
-pub use self::get_customer_with_orders::{
-    CustomerWithOrders,
-    GetCustomerWithOrders,
-    GetCustomerWithOrdersQuery,
+pub use self::{
+    get_customer::*,
+    get_customer_with_orders::*,
 };

--- a/src/domain/infra/func.rs
+++ b/src/domain/infra/func.rs
@@ -1,0 +1,65 @@
+use crate::domain::infra::Resolver;
+
+use std::future::Future;
+
+#[async_trait]
+pub trait Command<I, O> {
+    async fn execute(&mut self, input: I) -> O;
+}
+
+#[async_trait]
+impl<C, F, I, O> Command<I, O> for C
+where
+    C: FnMut(I) -> F + Send,
+    F: Future<Output = O> + Send,
+    I: Send + 'static,
+{
+    async fn execute(&mut self, input: I) -> O {
+        self(input).await
+    }
+}
+
+#[async_trait]
+pub trait Query<I, O> {
+    async fn execute(&self, input: I) -> O;
+}
+
+#[async_trait]
+impl<Q, F, I, O> Query<I, O> for Q
+where
+    Q: Fn(I) -> F + Sync,
+    F: Future<Output = O> + Send,
+    I: Send + 'static,
+{
+    async fn execute(&self, input: I) -> O {
+        self(input).await
+    }
+}
+
+impl Resolver {
+    pub(in crate::domain) fn command<C, F, I, O>(&self, mut command: C) -> impl Command<I, O>
+    where
+        C: FnMut(Resolver, I) -> F + Send,
+        F: Future<Output = O> + Send,
+        I: Send + 'static,
+    {
+        let resolver = self.by_ref();
+        move |input: I| {
+            let resolver = resolver.by_ref();
+            command(resolver, input)
+        }
+    }
+
+    pub(in crate::domain) fn query<Q, F, I, O>(&self, query: Q) -> impl Query<I, O>
+    where
+        Q: Fn(Resolver, I) -> F + Sync,
+        F: Future<Output = O> + Send,
+        I: Send + 'static,
+    {
+        let resolver = self.by_ref();
+        move |input: I| {
+            let resolver = resolver.by_ref();
+            query(resolver, input)
+        }
+    }
+}

--- a/src/domain/infra/future.rs
+++ b/src/domain/infra/future.rs
@@ -1,4 +1,0 @@
-pub(in crate::domain) type Future<T> =
-    ::std::pin::Pin<Box<dyn ::std::future::Future<Output = T> + Send>>;
-
-pub(in crate::domain) use futures::FutureExt;

--- a/src/domain/infra/mod.rs
+++ b/src/domain/infra/mod.rs
@@ -7,7 +7,7 @@ domain modules can use.
 
 pub(in crate::domain) mod currency;
 pub(in crate::domain) mod entity;
-pub(in crate::domain) mod future;
+pub mod func;
 pub(in crate::domain) mod id;
 pub(in crate::domain) mod resolver;
 pub(in crate::domain) mod transactions;
@@ -15,13 +15,11 @@ pub(in crate::domain) mod version;
 
 pub use self::{
     currency::*,
+    func::*,
     id::*,
     resolver::*,
     transactions::*,
     version::*,
 };
 
-pub(in crate::domain) use self::{
-    entity::*,
-    future::*,
-};
+pub(in crate::domain) use self::entity::*;

--- a/src/domain/infra/resolver.rs
+++ b/src/domain/infra/resolver.rs
@@ -54,6 +54,15 @@ pub struct Resolver {
 }
 
 impl Resolver {
+    pub(in crate::domain) fn by_ref(&self) -> Self {
+        Resolver {
+            transactions_resolver: self.transactions_resolver.clone(),
+            products_resolver: self.products_resolver.clone(),
+            orders_resolver: self.orders_resolver.clone(),
+            customers_resolver: self.customers_resolver.clone(),
+        }
+    }
+
     pub(in crate::domain) fn resolve<T>(&self, register: &Register<T>) -> T
     where
         T: Clone,

--- a/src/domain/infra/transactions/resolver.rs
+++ b/src/domain/infra/transactions/resolver.rs
@@ -93,9 +93,7 @@ impl Resolver {
                 transaction_store: self.transactions_resolver.transaction_store.clone(),
                 active_transaction,
             },
-            products_resolver: self.products_resolver.clone(),
-            orders_resolver: self.orders_resolver.clone(),
-            customers_resolver: self.customers_resolver.clone(),
+            ..self.by_ref()
         }
     }
 }

--- a/src/domain/orders/commands/create_order.rs
+++ b/src/domain/orders/commands/create_order.rs
@@ -8,7 +8,7 @@ use crate::domain::{
     Error,
 };
 
-pub type Result = ::std::result::Result<(), Error>;
+type Result = ::std::result::Result<(), Error>;
 
 /** Input for a `CreateOrderCommand`. */
 #[derive(Clone, Deserialize)]
@@ -17,38 +17,37 @@ pub struct CreateOrder {
     pub customer_id: CustomerId,
 }
 
-/** Create a new order. */
-#[auto_impl(FnMut)]
-pub trait CreateOrderCommand {
-    fn create_order(&mut self, command: CreateOrder) -> Result;
+impl CommandArgs for CreateOrder {
+    type Output = Result;
 }
 
-/** Default implementation for a `CreateOrderCommand`. */
-pub(in crate::domain) fn create_order_command(
-    transaction: ActiveTransaction,
-    store: impl OrderStore,
-    query: impl GetCustomerQuery,
-) -> impl CreateOrderCommand {
-    move |command: CreateOrder| {
-        debug!("creating order `{}`", command.id);
+impl CreateOrder {
+    async fn execute(
+        &mut self,
+        transaction: ActiveTransaction,
+        store: impl OrderStore,
+        customer_query: impl Query<GetCustomer>,
+    ) -> Result {
+        debug!("creating order `{}`", self.id);
 
         let order = {
-            if store.get_order(command.id)?.is_some() {
-                err!("order `{}` already exists", command.id)?
+            if store.get_order(self.id)?.is_some() {
+                err!("order `{}` already exists", self.id)?
             } else {
-                let customer = query
-                    .get_customer(GetCustomer {
-                        id: command.customer_id,
-                    })?
+                let customer = customer_query
+                    .execute(GetCustomer {
+                        id: self.customer_id,
+                    })
+                    .await?
                     .ok_or_else(|| error::bad_input("customer not found"))?;
 
-                Order::new(command.id, &customer)?
+                Order::new(self.id, &customer)?
             }
         };
 
         store.set_order(transaction.get(), order)?;
 
-        info!("created order `{}`", command.id);
+        info!("created order `{}`", self.id);
 
         Ok(())
     }
@@ -56,13 +55,17 @@ pub(in crate::domain) fn create_order_command(
 
 impl Resolver {
     /** Create an order. */
-    pub fn create_order_command(&self) -> impl CreateOrderCommand {
-        let store = self.order_store();
-        let active_transaction = self.active_transaction();
+    pub fn create_order_command(&self) -> impl Command<CreateOrder> {
+        self.command(|resolver, mut command: CreateOrder| async move {
+            let store = resolver.order_store();
+            let active_transaction = resolver.active_transaction();
 
-        let query = self.get_customer_query();
+            let customer_query = resolver.get_customer_query();
 
-        create_order_command(active_transaction, store, query)
+            command
+                .execute(active_transaction, store, customer_query)
+                .await
+        })
     }
 }
 
@@ -71,31 +74,31 @@ mod tests {
     use super::*;
 
     use crate::domain::{
-        customers::{
-            model::test_data::CustomerBuilder,
-            queries::get_customer::Result as QueryResult,
-        },
+        customers::model::test_data::CustomerBuilder,
         orders::model::store::in_memory_store,
     };
 
-    #[test]
-    fn err_if_already_exists() {
+    #[tokio::test]
+    async fn err_if_already_exists() {
         let store = in_memory_store(Default::default());
 
         let customer_id = CustomerId::new();
 
-        let create = CreateOrder {
+        let customer_query = |_| async { Ok(Some(CustomerBuilder::new().id(customer_id).build())) };
+
+        let mut create = CreateOrder {
             id: OrderId::new(),
             customer_id,
         };
 
-        let mut cmd = create_order_command(ActiveTransaction::none(), &store, move |_| {
-            let customer: QueryResult = Ok(Some(CustomerBuilder::new().id(customer_id).build()));
-            customer
-        });
+        create
+            .execute(ActiveTransaction::none(), &store, &customer_query)
+            .await
+            .unwrap();
 
-        cmd.create_order(create.clone()).unwrap();
-
-        assert!(cmd.create_order(create).is_err());
+        assert!(create
+            .execute(ActiveTransaction::none(), &store, &customer_query)
+            .await
+            .is_err());
     }
 }

--- a/src/domain/orders/commands/mod.rs
+++ b/src/domain/orders/commands/mod.rs
@@ -1,13 +1,9 @@
 /*! Commands for modifying order state. */
 
-pub mod add_or_update_product;
-pub use self::add_or_update_product::{
-    AddOrUpdateProduct,
-    AddOrUpdateProductCommand,
-};
+mod add_or_update_product;
+mod create_order;
 
-pub mod create_order;
-pub use self::create_order::{
-    CreateOrder,
-    CreateOrderCommand,
+pub use self::{
+    add_or_update_product::*,
+    create_order::*,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ extern crate log;
 #[macro_use]
 extern crate auto_impl;
 
+#[macro_use]
+extern crate async_trait;
+
 pub mod api;
 pub mod domain;
 pub mod logger;


### PR DESCRIPTION
I wasn’t really happy with how the first go at making our domain methods async turned out. The boxing and need to specify extra bounds was a bit clumsy.

This PR changes things up by using the `async_trait` crate to implement some core `Command<T>` and `Query<T>` traits. They have blanket implementations for fn types that produce futures so we can still pass closures around as commands and queries.

We can’t really use `auto_impl` anymore for these types because we don’t want to generate impls based directly off the item `async_trait` generates for us.